### PR TITLE
Update steps to give Aurora Access to Amazon S3

### DIFF
--- a/doc_source/AuroraMySQL.Integrating.LoadFromS3.md
+++ b/doc_source/AuroraMySQL.Integrating.LoadFromS3.md
@@ -7,11 +7,13 @@ Loading data into a table from text files in an Amazon S3 bucket is available fo
 
 ## Giving Aurora Access to Amazon S3<a name="AuroraMySQL.Integrating.LoadFromS3.Authorize"></a>
 
-Before you can load data from an Amazon S3 bucket, you must give your Aurora MySQL DB cluster permission to access Amazon S3\. To grant permission, create an AWS Identity and Access Management \(IAM\) role with the necessary permissions, and then associate the role with your DB cluster\. You must also configure your Aurora MySQL DB cluster to allow outbound connections to Amazon S3\. For details and instructions on how to permit your Aurora MySQL DB cluster to communicate with Amazon S3 on your behalf, see [Setting Up IAM Roles to Access AWS Services](AuroraMySQL.Integrating.Authorizing.IAM.md)\. 
+Before you can load data from an Amazon S3 bucket, you must give your Aurora MySQL DB cluster permission to access Amazon S3\. To grant permission, 
 
-**Note**  
-You must set either the `aurora_load_from_s3_role` or `aws_default_s3_role` DB cluster parameter to the Amazon Resource Name \(ARN\) of the new IAM role\. If an IAM role isn't specified for the `aurora_load_from_s3_role`, the IAM role specified in `aws_default_s3_role` is used\.   
-For more information about DB cluster parameters, see [Amazon Aurora DB Cluster and DB Instance Parameters](Aurora.Managing.md#Aurora.Managing.ParameterGroups)\.
+1. Create an AWS Identity and Access Management \(IAM\) role with the necessary permissions, and then associate the role with your DB cluster\. You must also configure your Aurora MySQL DB cluster to allow outbound connections to Amazon S3\. For details and instructions on how to permit your Aurora MySQL DB cluster to communicate with Amazon S3 on your behalf, see [Setting Up IAM Roles to Access AWS Services](AuroraMySQL.Integrating.Authorizing.IAM.md)\. 
+
+2. You must set either the `aurora_load_from_s3_role` or `aws_default_s3_role` DB cluster parameter to the Amazon Resource Name \(ARN\) of the new IAM role\. If an IAM role isn't specified for the `aurora_load_from_s3_role`, the IAM role specified in `aws_default_s3_role` is used\. For more information about DB cluster parameters, see [Amazon Aurora DB Cluster and DB Instance Parameters](Aurora.Managing.md#Aurora.Managing.ParameterGroups)\.
+
+3. To permit database users in an Amazon Aurora DB cluster to access S3, you associate the role that you created in [Creating an IAM Role to Allow Amazon Aurora to Access AWS Services](AuroraMySQL.Integrating.Authorizing.IAM.CreateRole.md) with that DB cluster. For associating an IAM role with a DB cluster, see [Associating an IAM Role with an Amazon Aurora DB Cluster](AuroraMySQL.Integrating.Authorizing.IAM.AddRoleToDBCluster.md)\.
 
 ## Granting Privileges to Load Data in Amazon Aurora MySQL<a name="AuroraMySQL.Integrating.LoadFromS3.Grant"></a>
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Current documentation does not mention a key step to allow database users in an Amazon Aurora DB cluster to access S3 by associating IAM role with an Amazon Aurora DB Cluster. If this step is not performed, an error is thrown by the sql client.
`ERROR 1871 (HY000): S3 API returned error: Missing Credentials: Cannot instantiate S3 Client`

2. Formatted steps as a bulleted list instead of paragraph

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
